### PR TITLE
Modify build to generate prerelease semver.

### DIFF
--- a/appveyor.yml
+++ b/appveyor.yml
@@ -6,7 +6,12 @@ install:
 - ps: >-
     if ($env:APPVEYOR_REPO_TAG -eq "false")
     {
-      $env:COMMIT_DESCRIPTION = git describe --tags
+      $version = & { git describe --tags } 2>&1
+      $baseVersion = (& { git describe --tags --abbrev=0 }) 2>&1
+      $prereleaseVersion = $version.SubString($baseVersion.Length)
+      $adjustedBaseVersion = $baseVersion.Split(".")
+      $adjustedBaseVersion[2] = ($adjustedBaseVersion[2] / 1) + 1
+      $env:COMMIT_DESCRIPTION = [System.String]::Join(".", $adjustedBaseVersion) + $prereleaseVersion
     }
     else
     {


### PR DESCRIPTION
Previously, we use some sort of post-release versioning with pre-release schema. For example, #3 builds as 0.0.0-xxx. This PR modifies the build script to generate a pre-release version instead (0.0.1-xxx).